### PR TITLE
fix monitoring scripts and api adapters that were silently broken

### DIFF
--- a/contracts/src/InfiniteBoost.sol
+++ b/contracts/src/InfiniteBoost.sol
@@ -468,10 +468,13 @@ contract InfiniteBoost is ReentrancyGuard, Ownable, Pausable {
         uint256 userBalance = balanceOf[msg.sender][lpToken];
         require(userBalance > 0, "No balance to withdraw" );
 
+        IGauge gauge = gauges[lpToken];
+        _updateRewards(msg.sender, lpToken);
+        rewards[msg.sender][lpToken] = 0;
+        userRewardPerTokenPaid[msg.sender][lpToken] = gauge.rewardPerToken();
 
         balanceOf[msg.sender][lpToken]=0;
 
-        IGauge gauge = gauges[lpToken];
         gauge.withdraw(userBalance);
         IERC20(lpToken).safeTransfer(msg.sender, userBalance);
 

--- a/src/R/api/adapter.R
+++ b/src/R/api/adapter.R
@@ -86,7 +86,7 @@ setSides <- function(
     }, error = function(e) {
       if (grepl("Timeout", e$message)) {
         print("Request timed out. Retrying...")
-      } else if (status_code(response) == 504) {
+      } else if (exists("response") && inherits(response, "response") && status_code(response) == 504) {
         print("Gateway Timeout. Retrying...")
       } else {
         print(paste("Request error occurred:", e$message))
@@ -106,7 +106,7 @@ response <- setSides(pair = "WBTC-USDC", side = "long")
 
 # Example usage to go neutral (USDC)
 
-response <- setSides(pair = "WBTC-USDC", side = "neutral")
+response <- setSides(pair = "WBTC-USDC", side = "cash")
 
 # Example usage to go short (BTCBEAR1X)
 

--- a/src/R/dHEDGE/dHEDGE_GraphQL.R
+++ b/src/R/dHEDGE/dHEDGE_GraphQL.R
@@ -20,10 +20,10 @@ getallFundsByTrader <- function(protocol,traderAddress) {
         if (protocol == "dhedge") {
                 operationsDoc <- sprintf('query allFundsByTrader { allFundsByTrader(traderAddress: "%s") { address blockchainCode } }', traderAddress)
                 result <- fetchGraphQL(operationsDoc, "allFundsByTrader", list())
+                if ("errors" %in% names(result)) { cat("Error:", result$errors[[1]]$message, "\n"); return(NULL)  }
                 n_pools = length(result$data$allFundsByTrader)
                 pools = c(); networks = c();
-                if ("errors" %in% names(result)) { cat("Error:", result$errors[[1]]$message, "\n"); return(NULL)  }
-                else if ("data" %in% names(result) && n_pools > 0) {
+                if ("data" %in% names(result) && n_pools > 0) {
                         for (i in 1:n_pools) {
                                 pools = c(pools,result$data$allFundsByTrader[[i]]$address)
                                 networks = c(networks,result$data$allFundsByTrader[[i]]$blockchainCode)
@@ -109,15 +109,15 @@ dhedge_graphql=function(query="composition",name=NULL){
   result <- content(response, "text") %>%
   fromJSON(flatten = TRUE)
   if (query == "composition") { 
-    fund_names = res$data$allFundsByManager$name
-    n = length(res$data$allFundsByManager$name)
+    fund_names = result$data$allFundsByManager$name
+    n = length(result$data$allFundsByManager$name)
     for (i in 1:n) { 
       if (is.null(name)) {
         print(paste0("Fund name: ",fund_names[i]))
-        print(res$data$allFundsByManager$fundComposition[[i]])
+        print(result$data$allFundsByManager$fundComposition[[i]])
       }
       else if (fund_names[i]==name) { 
-        composition = res$data$allFundsByManager$fundComposition[[i]]
+        composition = result$data$allFundsByManager$fundComposition[[i]]
         return(composition)
       }
     }
@@ -132,8 +132,9 @@ coin_amount = function(pool,coins) {
     if (any(comp$tokenName == coins[i])) { 
       index = which(comp$tokenName == coins[i])
       tokens_amount[i] = as.numeric(comp$amount[index])
-      if (name == "USDCe" || name == "USDT" || name == "USDC") { decimals = 6 }
-      else if (name == "WBTC") { decimals = 8 }
+      token = coins[i]
+      if (token == "USDCe" || token == "USDT" || token == "USDC") { decimals = 6 }
+      else if (token == "WBTC") { decimals = 8 }
       else { decimals = 18 }
       tokens_amount[i] = tokens_amount[i]/(10^decimals)
     }
@@ -155,7 +156,7 @@ while (1) {
   }
   name = "Ethereum Savings Account"
   deposits = coin_amount(pool=name,coins=c("WETH"))
-  if (deposits >= 0.01) {
+  if (deposits[1] >= 0.01) {
     discord(msg=paste0("Vault: ",name," WETH Balance: ",deposits[1]),channel="#deposits-alerts")
   }
   Sys.sleep(1)

--- a/src/R/dexscreener/itp_incentives.R
+++ b/src/R/dexscreener/itp_incentives.R
@@ -91,6 +91,9 @@ incentives = function(network,exchange,liquidity_percentage,lps) {
   # Fetch data for each LP
   for (lp in lps) {
     liquidity_data <- ds_price(pair = lp, network = network, exchange = exchange, liquidity = TRUE)
+    if (is.null(liquidity_data)) {
+      stop(paste("failed to fetch liquidity data for", lp, "from dexscreener"))
+    }
     usd_liquidity <- c(usd_liquidity, liquidity_data$usd / 2)
     prices <- c(prices, liquidity_data$price)
   }

--- a/src/R/dexscreener/price_monitoring.R
+++ b/src/R/dexscreener/price_monitoring.R
@@ -41,9 +41,9 @@ ds_price = function(pair, network, exchange, native = FALSE) {
     data <- fromJSON(content(response, "text"))
     # Return either USD or native price
     if (!native) {
-      return(as.numeric(data$pairs$priceUsd))
+      return(as.numeric(data$pair$priceUsd))
     } else {
-      return(data$pairs$priceNative)
+      return(data$pair$priceNative)
     }
   } else {
     cat("Error:", http_status(response)$reason, "\n")

--- a/src/R/utils/correlation_analysis.R
+++ b/src/R/utils/correlation_analysis.R
@@ -49,6 +49,7 @@ end_date <- "2023-11-01"
 # FTSE 100 Index
 symbol <- "^FTSE"
 getSymbols(symbol, from = start_date, to = end_date, src = "yahoo")
+FTSE <- to.monthly(`^FTSE`, OHLC = TRUE, indexAt = "endof")
 
 # S&P 500 E-mini Futures
 symbol <- "ES=F"

--- a/src/Typescript/api/adapter.ts
+++ b/src/Typescript/api/adapter.ts
@@ -94,7 +94,7 @@ async function setSides({
 
     for (let attempt = 0; attempt < retries; attempt++) {
         try {
-            const response = await axios.post(endpoint, { params, timeout: timeout * 1000 });
+            const response = await axios.post(endpoint, null, { params, timeout: timeout * 1000 });
             if (response.status === 200) {
                 console.log('Trade executed successfully');
                 return response.data;

--- a/src/python/defi.py
+++ b/src/python/defi.py
@@ -34,7 +34,7 @@ coins_list = [
         {"coin": "SNX", "contract": "0x50b728d8d964fd00c2d0aad81718b71311fef68a", "network": "polygon","pair":"SNX-USD"},
         {"coin": "PAXG", "contract": "0x553d3d295e0f695b9228246232edf400ed3560b5", "network": "polygon","pair":"PAXG-USD"},
         {"coin": "OP", "contract": "0x4200000000000000000000000000000000000042", "network": "optimism","pair":"OP-USD"},
-        {"coin": "USDC", "contract": "0x7f5c764cbc14f9669b88837ca1490cca17c31607", "network": "optimism","pair":"USD-USD"},
+        {"coin": "USDC", "contract": "0x7f5c764cbc14f9669b88837ca1490cca17c31607", "network": "optimism","pair":"USDC-USD"},
         {"coin": "DHT", "contract": "0xaf9fe3b5ccdae78188b1f8b9a49da7ae9510f151", "network": "optimism","pair":"DHT-USD"},
         {"coin": "WETH", "contract": "0x4200000000000000000000000000000000000006", "network": "optimism","pair":"ETH-USD"},
         {"coin": "wstETH", "contract": "0x1f32b1c2345538c0c6f582fcb022739c4a194ebb", "network": "optimism","pair":"wstETH-USD"},
@@ -71,7 +71,7 @@ def contract_to_coin(contract,network):
     for item in coins_list:
         if item['contract'].lower() == contract.lower() and item['network'].lower() == network.lower():
                 return item['coin']
-        return None
+    return None
 
 def coin_from_contract(contract,network):
     for item in coins_list:
@@ -120,7 +120,7 @@ def dhedgeComposition(pool,network):
     df['symbol'] = df['asset'].apply(lambda x: coin_from_contract(x.lower(), network))
     df['assetPair'] = df['asset'].apply(lambda x: pair_from_contract(x.lower(),network))
     # Apply the 'decimals' function
-    df['amount'] = df.apply(lambda row: row['balance'] / (10 ** decimals(row['asset'])), axis=1)
+    df['amount'] = df.apply(lambda row: row['balance'] / (10 ** decimals(row['symbol'])), axis=1)
     df['price'] = df['rate'] / (10 ** 18)
     df = df.drop(['balance','rate'], axis=1)
     return df
@@ -167,7 +167,7 @@ def tx_status(hash, network):
         raise ValueError("Error: Transaction not found or invalid transaction hash.")
 
     # Return the transaction status
-    if network == "mainnet" or network == "optimism":
+    if network == "mainnet" or network == "optimism" or network == "arbitrum":
         if api_content["result"]["isError"] == "1":
             return "Error"
         elif int(api_content["result"]["status"]) == 1:
@@ -202,6 +202,9 @@ def wallet_balance(address, network):
 
     # Parse the JSON response
     content = json.loads(response.content)
+
+    if content.get("status") != "1":
+        raise ValueError(f"Error: Etherscan API returned status {content.get('status')}: {content.get('message', content.get('result'))}")
 
     # Extract the gas balance
     gas_balance = float(content["result"]) / 10**18

--- a/src/python/itp_incentives_dexscreener.py
+++ b/src/python/itp_incentives_dexscreener.py
@@ -86,6 +86,8 @@ prices = []
 # Fetch data for each LP
 for lp in lps:
     liquidity_data = ds_price(pair=lp, network="optimism", exchange="velodromeV2", liquidity=True)
+    if liquidity_data is None:
+        raise RuntimeError(f"failed to fetch liquidity data for {lp} from dexscreener")
     usd_liquidity.append(liquidity_data["usd"] / 2)
     prices.append(liquidity_data["price"])
     print(f"LP: {lp}, Liquidity: {usd_liquidity[-1]}")


### PR DESCRIPTION
hey team, its moondev. checked the codebase and found a few things that looked broken in production, not sure if helpful but figured id send a pr.

**typescript api adapter** - setSides was doing axios.post(endpoint, { params, timeout }) which sends params as a json body. python and R both send them as query params. every typescript bot config call would hit the wrong payload shape.

**dhedge deposit monitor (R)** - dhedge_graphql parsed json into `result` but then read from `res`, so coin_amount and the deposit alert loop would crash every iteration. also coin_amount used the outer loop pool name for decimal scaling instead of the actual token symbol, so USDC/WBTC amounts were off by orders of magnitude.

**dexscreener price monitor (R)** - single-pair endpoint returns `pair` not `pairs`. price was always null so threshold alerts never fired.

**defi.py** - contract_to_coin had return None inside the for loop so only the first token in the list could ever match. dhedgeComposition was passing contract hex addresses into decimals() instead of symbols, so all pool balances scaled as 18 decimals. also added arbitrum to tx_status and proper etherscan error handling in wallet_balance.

**itp incentives scripts** - python and R versions would crash mid-run if dexscreener returned a non-200, sometimes after already printing partial numbers for earlier pools.

**infiniteboost emergencyWithdraw** - zeroed lp balance but left rewards and userRewardPerTokenPaid untouched. after unpause someone could claim boost rewards for stake they already exited through the emergency path.

**correlation_analysis.R** - getSymbols creates `^FTSE` not FTSE, script died at the merge step.

cheers